### PR TITLE
Update global bill pay submission success message

### DIFF
--- a/app/src/app/core/constants/billpayconstants.ts
+++ b/app/src/app/core/constants/billpayconstants.ts
@@ -8,7 +8,7 @@ export const BillPayConstants = {
     PaymentIncomplete: "Payment - Incomplete",
     LargeGroupBillValidationMsg: "Additional Large Group Bill copies require payment data entry, payment data will be sent after all have been completed.",
     UBMGroupValidationMsg:"Additional UBM invoices require payment data entry, payment data will be sent after all have been completed.",
-    Success: "Payment Data Sent",
+    Success: "payment submitted to d365",
     Hold: "Hold",
     GroupBill: "Not part of Group Bill",
     PaymentAccountSetupIssueException: "PaymentAccountSetupIssue",

--- a/app/src/app/core/constants/billpayconstants.ts
+++ b/app/src/app/core/constants/billpayconstants.ts
@@ -8,7 +8,7 @@ export const BillPayConstants = {
     PaymentIncomplete: "Payment - Incomplete",
     LargeGroupBillValidationMsg: "Additional Large Group Bill copies require payment data entry, payment data will be sent after all have been completed.",
     UBMGroupValidationMsg:"Additional UBM invoices require payment data entry, payment data will be sent after all have been completed.",
-    Success: "payment submitted to d365",
+    Success: "Payment submitted but it went to AI pocket",
     Hold: "Hold",
     GroupBill: "Not part of Group Bill",
     PaymentAccountSetupIssueException: "PaymentAccountSetupIssue",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the global bill pay post-submission success message to `Payment submitted but it went to AI pocket`.

## Testing
- `npm run build` (passes; existing warnings about unused environment files)

## Notes
- Earlier verification showed `npm test -- --watch=false --browsers=ChromeHeadless` fails before specs execute because `src/test.ts` calls `require.context`, which is unavailable in the current Karma/Webpack runtime.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66a155ff-0f57-4912-baac-45e2366f08ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66a155ff-0f57-4912-baac-45e2366f08ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

